### PR TITLE
Fix for menu border getting cut off on smaller screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,12 +131,12 @@ div.about{
 	div#menu {
 		position: fixed;
 		width:100%;
-        box-sizing: border-box;
 		font-size: 16px;
 		line-height: 22px;
 		padding: 10px;
 		z-index:10;
 		left: 2px;
+        right: 2px;
 		top: 2px;
 	}
 	img#logo{

--- a/style.css
+++ b/style.css
@@ -130,7 +130,8 @@ div.about{
 	}
 	div#menu {
 		position: fixed;
-		width:95%;
+		width:100%;
+        box-sizing: border-box;
 		font-size: 16px;
 		line-height: 22px;
 		padding: 10px;


### PR DESCRIPTION
Hey Clem,

I found a bug in the mobile menu display and have sent over a quick fix I tested in Chrome on my machine tonight. It keeps the menu border on the screen so it looks better.

<img width="402" alt="screen shot 2016-01-18 at 12 39 59 am" src="https://cloud.githubusercontent.com/assets/1010790/12384114/6a39d222-bd7c-11e5-826d-b4ebb50e69ad.png">

Hope that helps
