### PR TITLE
Improving menu experience on web and touch devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
         <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
-
+        <script src="js/vendor/jquery.ui.touch-punch.min.js"></script>
         <script src="js/google-docs-site.1.0.js"></script>
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
                 <div></div>
                 <div></div>
             </div>
+            <img id="logo-touch" src="logo.png">
             <ul id="navigation">
             </ul>
         </div>

--- a/js/google-docs-site.1.0.js
+++ b/js/google-docs-site.1.0.js
@@ -48,6 +48,8 @@ $(function() {
 	//mobile hack
 	if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
  		mobile = true;
+        // Add body class to target styles for touch devices with CSS
+        $('body').addClass('touch-device');
 	}
 
 });

--- a/js/google-docs-site.1.0.js
+++ b/js/google-docs-site.1.0.js
@@ -48,6 +48,9 @@ $(function() {
     // and reset it gracefully when transitioning to narrower views
     // 768 matches the CSS mobile breakpoint, if you change it here
     // change it in the CSS as well. Thanks!
+    //
+    // N.B. If touch-punch is imported, this doesn't prevent moving the menu
+    // around on touch devices. If you don't like that remove touch-punch.
     $(window).resize(function() {
         if(window.innerWidth < 768) {
             $("#menu").draggable('disable').attr('style','');

--- a/js/google-docs-site.1.0.js
+++ b/js/google-docs-site.1.0.js
@@ -48,15 +48,6 @@ $(function() {
 	//mobile hack
 	if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
  		mobile = true;
-
- 		//setup the iframe width resize
-		$("iframe").css( "width",$(window).width()-50+"px" );
-		$("#menu").css( "width",$(window).width()-30+"px" );
-		$( window ).resize(function() {
-	  		$("iframe").css( "width",$(window).width()-50+"px" );
-	  		$("#menu").css( "width",$(window).width()-30+"px" );
-		});
-
 	}
 
 });

--- a/js/google-docs-site.1.0.js
+++ b/js/google-docs-site.1.0.js
@@ -40,9 +40,22 @@ $(function() {
 			$("#menu").toggleClass("border");
 		});
 
-		$( "#menu" ).draggable({ cancel: "li" });
+		$("#menu").draggable({ cancel: "li" });
     	// $( "div, p" ).disableSelection();
 	});
+
+    // Keep navigation from getting borked when dragged on wider views
+    // and reset it gracefully when transitioning to narrower views
+    // 768 matches the CSS mobile breakpoint, if you change it here
+    // change it in the CSS as well. Thanks!
+    $(window).resize(function() {
+        if(window.innerWidth < 768) {
+            $("#menu").draggable('disable').attr('style','');
+        } else if(window.innerWidth > 768) {
+            $("#menu").draggable('enable');
+            $("#navigation").attr('style','');
+        };
+    });
 	
 	//little fix for the iframe size on mobile
 	//mobile hack

--- a/js/vendor/jquery.ui.touch-punch.min.js
+++ b/js/vendor/jquery.ui.touch-punch.min.js
@@ -1,0 +1,11 @@
+/*!
+ ** jQuery UI Touch Punch 0.2.3
+ **
+ ** Copyright 2011–2014, Dave Furfero
+ ** Dual licensed under the MIT or GPL Version 2 licenses.
+ **
+ ** Depends:
+ **  jquery.ui.widget.js
+ **  jquery.ui.mouse.js
+ **/
+!function(a){function f(a,b){if(!(a.originalEvent.touches.length>1)){a.preventDefault();var c=a.originalEvent.changedTouches[0],d=document.createEvent("MouseEvents");d.initMouseEvent(b,!0,!0,window,1,c.screenX,c.screenY,c.clientX,c.clientY,!1,!1,!1,!1,0,null),a.target.dispatchEvent(d)}}if(a.support.touch="ontouchend"in document,a.support.touch){var e,b=a.ui.mouse.prototype,c=b._mouseInit,d=b._mouseDestroy;b._touchStart=function(a){var b=this;!e&&b._mouseCapture(a.originalEvent.changedTouches[0])&&(e=!0,b._touchMoved=!1,f(a,"mouseover"),f(a,"mousemove"),f(a,"mousedown"))},b._touchMove=function(a){e&&(this._touchMoved=!0,f(a,"mousemove"))},b._touchEnd=function(a){e&&(f(a,"mouseup"),f(a,"mouseout"),this._touchMoved||f(a,"click"),e=!1)},b._mouseInit=function(){var b=this;b.element.bind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),c.call(b)},b._mouseDestroy=function(){var b=this;b.element.unbind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),d.call(b)}}}(jQuery);

--- a/style.css
+++ b/style.css
@@ -164,8 +164,6 @@ body {
 	    margin-bottom: 15%;
 	    width: 90%;
 	}
-	.border{
-	}
 	.about{
 		width: auto;
 		display: none;

--- a/style.css
+++ b/style.css
@@ -58,6 +58,15 @@ body {
 	top: 60px;
 	width: 300px;
 }
+    #logo-touch {
+        display: none;
+		position: absolute;
+		left:50%;
+		top:4px;
+		margin-left: -80px;
+		width:160px;
+		margin: left:10%;
+    }
 
 #binder-clip{
 	margin-top: -38px;
@@ -124,13 +133,11 @@ body {
     }
 
 	.touch-device #logo{
-		position: fixed;
-		left:50%;
-		top:10px;
-		margin-left: -80px;
-		width:160px;
-		margin: left:10%;
+        display: none;
 	}
+	.touch-device #logo-touch{
+        display: block;
+    }
 	.touch-device #navigation{
 		display: none;
 		text-indent: -1.5em;
@@ -180,13 +187,11 @@ body {
 		top: 2px;
 	}
 	#logo{
-		position: fixed;
-		left:50%;
-		top:10px;
-		margin-left: -80px;
-		width:160px;
-		margin: left:10%;
+        display: none;
 	}
+    #logo-touch {
+        display: block;
+    }
 	#navigation{
 		display: none;
 		text-indent: -1.5em;

--- a/style.css
+++ b/style.css
@@ -17,7 +17,6 @@ body {
 	position: relative;
 	width: 100%;
 	height: 100%;
-	min-width: 900px;
 }
 
 div#background-site {
@@ -114,7 +113,7 @@ div.about{
 
 
 /* @group mobile */
-@media only screen and (max-width: 720px) {
+@media only screen and (max-width: 768px) {
 	body, html{
 	position: relative;
 		width: 100%;
@@ -130,7 +129,6 @@ div.about{
 	}
 	div#menu {
 		position: fixed;
-		width:100%;
 		font-size: 16px;
 		line-height: 22px;
 		padding: 10px;

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: Clement Valla
 Version: 1.0
 */
 
- *{
+*{
  	margin: 0;
 	padding: 0;
  }
@@ -19,21 +19,21 @@ body {
 	height: 100%;
 }
 
-div#background-site {
+#background-site {
 	position: absolute;
 	width: 100%;
 	height: 100%;
 	z-index:1;
 }
 
-div#background-site iframe {
+#background-site iframe {
 	width: 100%;
 	height: 100%;
 	border: none;
 	overflow: scroll;
 }
 
-div#menu {
+#menu {
 	position: fixed;
 	left: 10px;
 	top: 40%;
@@ -51,7 +51,7 @@ div#menu {
 	background-color: #eee;
 }
 
-img#logo {
+#logo {
 	z-index: 20;
 	position: fixed;
 	right: 70px;
@@ -59,7 +59,7 @@ img#logo {
 	width: 300px;
 }
 
-img#binder-clip{
+#binder-clip{
 	margin-top: -38px;
     position: fixed;
     margin-left: 80px;
@@ -69,35 +69,35 @@ img#binder-clip{
     transform: rotate(-27deg);
 }
 
-ul#navigation {
+#navigation {
 	margin: 0;
 	padding:0;
 	list-style-type: none;
 }
 
-ul#navigation li{
+#navigation li{
 	padding:0;
 	margin:0;
 	width:auto;
 }
 
-ul#navigation a, div.about{
+#navigation a, div.about{
 	color: #717171;
 	padding: 0;
 	text-decoration: none;
 	padding: 1px;
 }
-ul#navigation a.active{
+#navigation a.active{
 	color: #000;
 }
-ul#navigation a:hover{
+#navigation a:hover{
 	color: #000;
 }
-ul#navigation .current_page_item a {
+#navigation .current_page_item a {
 	color: red;
 }
 
-div.about{
+.about{
 	position: fixed;
 	font-family: courier;
     letter-spacing: 0.5px;
@@ -118,16 +118,16 @@ div.about{
 	position: relative;
 		width: 100%;
 	}
-	div#background-site{
+	#background-site{
 		-webkit-overflow-scrolling:touch; 
 		overflow:auto;
 	}
-	div#background-site iframe{
+	#background-site iframe{
 		width: 100%;
 		height: 5500px;
 		overflow: hidden;
 	}
-	div#menu {
+	#menu {
 		position: fixed;
 		font-size: 16px;
 		line-height: 22px;
@@ -137,7 +137,7 @@ div.about{
         right: 2px;
 		top: 2px;
 	}
-	img#logo{
+	#logo{
 		position: fixed;
 		left:50%;
 		top:10px;
@@ -145,18 +145,18 @@ div.about{
 		width:160px;
 		margin: left:10%;
 	}
-	ul#navigation{
+	#navigation{
 		display: none;
 		text-indent: -1.5em;
 		margin-left:1.5em; 
 		margin-top: 20px;
 	}
-	div#menu-open{
+	#menu-open{
 		width: 30px;
 		height: 35px;
 		cursor: pointer;
 	}
-	div#menu-open div {
+	#menu-open div {
 	    background-color: black;
 	    border: 1px solid black;
 	    border-radius: 2px 2px 2px 2px;
@@ -166,7 +166,7 @@ div.about{
 	}
 	.border{
 	}
-	div.about{
+	.about{
 		width: auto;
 		display: none;
 	}

--- a/style.css
+++ b/style.css
@@ -111,8 +111,50 @@ body {
 	top: 155px;
 }
 
+/* Psuedo mobile styles for wide touch devices */
+    .touch-device #menu {
+        position: fixed;
+        font-size: 16px;
+        line-height: 22px;
+        padding: 10px;
+        z-index:10;
+        left: 2px;
+        right: 2px;
+        top: 2px;
+    }
 
-/* @group mobile */
+	.touch-device #logo{
+		position: fixed;
+		left:50%;
+		top:10px;
+		margin-left: -80px;
+		width:160px;
+		margin: left:10%;
+	}
+	.touch-device #navigation{
+		display: none;
+		text-indent: -1.5em;
+		margin-left:1.5em;
+		margin-top: 20px;
+	}
+	.touch-device #menu-open{
+		width: 30px;
+		height: 35px;
+		cursor: pointer;
+	}
+	.touch-device #menu-open div {
+	    background-color: black;
+	    border: 1px solid black;
+	    border-radius: 2px 2px 2px 2px;
+	    height: 15%;
+	    margin-bottom: 15%;
+	    width: 90%;
+	}
+	.touch-device .about{
+		width: auto;
+		display: none;
+	}
+/* Real mobile styles for smaller screens */
 @media only screen and (max-width: 768px) {
 	body, html{
 	position: relative;


### PR DESCRIPTION
Hey Clem,

This is a patch to fix all the bugs with the mobile/touch menu. It does a few handy things:
- Creates graceful transitions and position reset when scaling above and below 768px width on mobile and desktop web
- Keeps the menu draggable on touch devices so folks can move it out of the way if necessary
- Moves the logo into the menu on mobile/touch so when folks move it around, it looks good
- Cleans up some of the CSS and JS that isn't being used
- Removes JS width assignments for menu and iframe in favor of friendly CSS styles

If you want to experiment with this you can pull down my branch or repo and do some testing on your own : )

:+1: 

This will fix Cayley's bugs.

Goodnight! :moon: :sleeping:
